### PR TITLE
use SOURCE_PATH in browserify path setting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,7 +121,7 @@ function build() {
     logBuildMode();
 
     return browserify({
-        paths: [ path.join(__dirname, 'src') ],
+        paths: [ path.join(__dirname, SOURCE_PATH) ],
         entries: ENTRY_FILE,
         debug: true
     })


### PR DESCRIPTION
Found this when we moved the location of our client-side source code and browserify broke.  This fixes it!
