### PR TITLE
disable browsersync'ing of clicks, typing, forms, etc

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -145,6 +145,7 @@ function build() {
 function serve() {
 
     var options = {
+        ghostMode: false,
         ui: {
           port: 3001
         },


### PR DESCRIPTION
Feel free to accept or reject this based on personal preference.  By default browsersync will "replay" your clicks and keypresses across all open windows.  This kept getting in the way for our game so we enabled browsersync [ghostMode](https://www.browsersync.io/docs/options/#option-ghostMode).

It worked great for us (since we had a multiplayer game, we had multiple browsers open frequently and didn't want the same actions in each window).
